### PR TITLE
pgbouncer chart client/server tls support

### DIFF
--- a/pgbouncer/Chart.yaml
+++ b/pgbouncer/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: "1.0"
-version: 1.0.8
+version: 1.1.0
 description: PgBouncer chart, folked from https://github.com/cradlepoint/kubernetes-helm-chart-pgbouncer with some custom values
 name: pgbouncer
 home: https://github.com/duyet/charts/tree/master/pgbouncer

--- a/pgbouncer/templates/_pgbouncer.ini.tpl
+++ b/pgbouncer/templates/_pgbouncer.ini.tpl
@@ -32,8 +32,8 @@ unix_socket_dir = var/run/postgresql
 {{- if .Values.tls.client.enabled }}
 ;client_tls_sslmode = {{ .Values.tls.client.sslmode }}
 ;client_tls_ca_file = {{ .Values.tls.client.ca | default "<system default>" }}
-;client_tls_key_file = /etc/pgbouncer/tls/{{ .Values.tls.client.key }}
-;client_tls_cert_file = /etc/pgbouncer/tls/{{ .Values.tls.client.cert }}
+;client_tls_key_file = /etc/pgbouncer/tls/client/{{ .Values.tls.client.key }}
+;client_tls_cert_file = /etc/pgbouncer/tls/client/{{ .Values.tls.client.cert }}
 ;client_tls_ciphers = {{ .Values.tls.client.ciphers }}
 ;client_tls_protocols = {{ .Values.tls.client.protocols }}
 ;client_tls_dheparams = {{ .Values.tls.client.dheParams }}
@@ -51,8 +51,8 @@ unix_socket_dir = var/run/postgresql
 {{- if .Values.tls.server.enabled }}
 ;server_tls_sslmode = {{ .Values.tls.client.sslmode }}
 ;server_tls_ca_file = {{ .Values.tls.server.ca | default "<system default>" }}
-;server_tls_key_file = /etc/pgbouncer/tls/{{ .Values.tls.server.key }}
-;server_tls_cert_file = /etc/pgbouncer/tls/{{ .Values.tls.server.cert }}
+;server_tls_key_file = /etc/pgbouncer/tls/server/{{ .Values.tls.server.key }}
+;server_tls_cert_file = /etc/pgbouncer/tls/server/{{ .Values.tls.server.cert }}
 ;server_tls_protocols = {{ .Values.tls.server.protocols }}
 ;server_tls_ciphers = {{ .Values.tls.server.ciphers }}
 ; any, trust, plain, crypt, md5, cert, hba, pam

--- a/pgbouncer/templates/_pgbouncer.ini.tpl
+++ b/pgbouncer/templates/_pgbouncer.ini.tpl
@@ -28,6 +28,17 @@ listen_port = 5432
 unix_socket_dir = var/run/postgresql
 ;unix_socket_mode = 0777
 ;unix_socket_group =
+
+{{- if .Values.tls.client.enabled }}
+;client_tls_sslmode = {{ .Values.tls.client.sslmode }}
+;client_tls_ca_file = {{ .Values.tls.client.ca | default "<system default>" }}
+;client_tls_key_file = /etc/pgbouncer/tls/{{ .Values.tls.client.key }}
+;client_tls_cert_file = /etc/pgbouncer/tls/{{ .Values.tls.client.cert }}
+;client_tls_ciphers = {{ .Values.tls.client.ciphers }}
+;client_tls_protocols = {{ .Values.tls.client.protocols }}
+;client_tls_dheparams = {{ .Values.tls.client.dheParams }}
+;client_tls_ecdhcurve = {{ .Values.tls.client.ecdhCurve }}
+{{- else }}
 ;client_tls_sslmode = disable
 ;client_tls_ca_file = <system default>
 ;client_tls_key_file =
@@ -36,6 +47,16 @@ unix_socket_dir = var/run/postgresql
 ;client_tls_protocols = all
 ;client_tls_dheparams = auto
 ;client_tls_ecdhcurve = auto
+{{- end }}
+{{- if .Values.tls.server.enabled }}
+;server_tls_sslmode = {{ .Values.tls.client.sslmode }}
+;server_tls_ca_file = {{ .Values.tls.server.ca | default "<system default>" }}
+;server_tls_key_file = /etc/pgbouncer/tls/{{ .Values.tls.server.key }}
+;server_tls_cert_file = /etc/pgbouncer/tls/{{ .Values.tls.server.cert }}
+;server_tls_protocols = {{ .Values.tls.server.protocols }}
+;server_tls_ciphers = {{ .Values.tls.server.ciphers }}
+; any, trust, plain, crypt, md5, cert, hba, pam
+{{- else }}
 ;server_tls_sslmode = disable
 ;server_tls_ca_file = <system default>
 ;server_tls_key_file =
@@ -43,6 +64,7 @@ unix_socket_dir = var/run/postgresql
 ;server_tls_protocols = all
 ;server_tls_ciphers = fast
 ; any, trust, plain, crypt, md5, cert, hba, pam
+{{- end }}
 
 ;;; Authentication settings
 

--- a/pgbouncer/templates/deployment.yaml
+++ b/pgbouncer/templates/deployment.yaml
@@ -58,6 +58,11 @@ spec:
         - name: secret
           secret:
             secretName: {{ include "pgbouncer.fullname" . }}-secret
+      {{- if .Values.tls.enabled }}
+        - name: tls
+          secret:
+            secretName: {{ .Values.tls.secretName }}
+      {{- end }}
       containers:
         - name: pgbouncer
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -82,6 +87,11 @@ spec:
               subPath: pgbouncer.ini
               mountPath: /etc/pgbouncer/pgbouncer.ini
               readOnly: true
+            {{- if .Values.tls.enabled }}
+            - name: tls
+              mountPath: /etc/pgbouncer/tls
+              readOnly: true
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
 

--- a/pgbouncer/templates/deployment.yaml
+++ b/pgbouncer/templates/deployment.yaml
@@ -58,10 +58,15 @@ spec:
         - name: secret
           secret:
             secretName: {{ include "pgbouncer.fullname" . }}-secret
-      {{- if .Values.tls.enabled }}
-        - name: tls
+      {{- if .Values.tls.client.enabled }}
+        - name: tls-client
           secret:
-            secretName: {{ .Values.tls.secretName }}
+            secretName: {{ .Values.tls.client.secretName }}
+      {{- end }}
+      {{- if .Values.tls.server.enabled }}
+        - name: tls-server
+          secret:
+            secretName: {{ .Values.tls.server.secretName }}
       {{- end }}
       containers:
         - name: pgbouncer
@@ -87,9 +92,14 @@ spec:
               subPath: pgbouncer.ini
               mountPath: /etc/pgbouncer/pgbouncer.ini
               readOnly: true
-            {{- if .Values.tls.enabled }}
-            - name: tls
-              mountPath: /etc/pgbouncer/tls
+            {{- if .Values.tls.client.enabled }}
+            - name: tls-client
+              mountPath: /etc/pgbouncer/tls/client
+              readOnly: true
+            {{- end }}
+            {{- if .Values.tls.server.enabled }}
+            - name: tls-server
+              mountPath: /etc/pgbouncer/tls/server
               readOnly: true
             {{- end }}
           resources:

--- a/pgbouncer/values.yaml
+++ b/pgbouncer/values.yaml
@@ -75,16 +75,20 @@ global:
   namespacedDatabases: false
 
 tls:
-  #secretName: pgbouncer-tls
+  secretName: pgbouncer-tls
   client:
     enabled: false
     sslmode: prefer
     key: "tls.key"
     cert: "tls.crt"
     ciphers: fast
-    tlsProtocols: secure
+    protocols: secure
     dheParams: auto
     ecdhCurve: auto
   server:
     enabled: false
     sslmode: prefer
+    key: "tls.key"
+    cert: "tls.crt"
+    ciphers: fast
+    protocols: secure

--- a/pgbouncer/values.yaml
+++ b/pgbouncer/values.yaml
@@ -73,3 +73,18 @@ service:
 global:
   # optionally use namespace as dbname
   namespacedDatabases: false
+
+tls:
+  #secretName: pgbouncer-tls
+  client:
+    enabled: false
+    sslmode: prefer
+    key: "tls.key"
+    cert: "tls.crt"
+    ciphers: fast
+    tlsProtocols: secure
+    dheParams: auto
+    ecdhCurve: auto
+  server:
+    enabled: false
+    sslmode: prefer

--- a/pgbouncer/values.yaml
+++ b/pgbouncer/values.yaml
@@ -74,21 +74,32 @@ global:
   # optionally use namespace as dbname
   namespacedDatabases: false
 
+# optional client and server tls settings.  See https://www.pgbouncer.org/config.html#tls-settings
+# for details.
 tls:
-  secretName: pgbouncer-tls
   client:
+    # when true, enables tls settings for connections from clients
     enabled: false
-    sslmode: prefer
+    # the name of a kubernetes secret that contains the certificate and key for the tls connection
+    secretName: pgbouncer-client-tls
+    # value in kubernetes secret to use as the key
     key: "tls.key"
+    #value in the kubernetes secret to use as the cert
     cert: "tls.crt"
+    sslmode: prefer
     ciphers: fast
     protocols: secure
     dheParams: auto
     ecdhCurve: auto
   server:
+    # when true, enables tls settings for connections to postgres servers
     enabled: false
-    sslmode: prefer
+    # the name of a kubernetes secret that contains the certificate and key for the tls connection
+    secretName: pgbouncer-server-tls
+    # value in the kubernetes secret to use as the key
     key: "tls.key"
+    # value in the kubernetes secret to use as the cert
     cert: "tls.crt"
+    sslmode: prefer
     ciphers: fast
     protocols: secure


### PR DESCRIPTION
This PR adds support for updating the client and server tls settings for pgbouncer.  Setting `tls.client.enabled` or `tls.server.enabled` allows updating of the `client_tls*` and `server_tls*` settings in pgbouncer.  

When these settings are enabled a secret (specified by `tls.client.secretName`/`tls.server.secretName`) is mounted to the pods to provide the required certs.  The `key` and `cert` variables by default are compatible with the naming LetsEncrypt certificates issued by cert-manager use.