### PR TITLE
chore: update rules/path for ingress

### DIFF
--- a/uptime-kuma/templates/ingress.yaml
+++ b/uptime-kuma/templates/ingress.yaml
@@ -1,9 +1,10 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "uptime-kuma.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- $kubeVersion := .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.19-0" $kubeVersion -}}
 apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- else if semverCompare ">=1.14-0" $kubeVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -35,9 +36,18 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
+            {{- if semverCompare ">=1.19-0" $kubeVersion }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullName }}
+                port: 
+                  number: {{ $svcPort }}
+            {{- else -}}
             backend:
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
+            {{- end }}
           {{- end }}
     {{- end }}
   {{- end }}


### PR DESCRIPTION
Update because new networking.k8s.io/v1 has another structure, see https://kubernetes.io/docs/concepts/services-networking/ingress/