### PR TITLE
feat(clickhouse-monitoring): add cronjob

### DIFF
--- a/clickhouse-monitoring/Chart.yaml
+++ b/clickhouse-monitoring/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/clickhouse-monitoring/README.md
+++ b/clickhouse-monitoring/README.md
@@ -1,6 +1,6 @@
 # clickhouse-monitoring
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
 
 A Helm chart for ClickHouse Monitoring (https://github.com/duyet/clickhouse-monitoring)
 
@@ -21,6 +21,15 @@ A Helm chart for ClickHouse Monitoring (https://github.com/duyet/clickhouse-moni
 | autoscaling.maxReplicas | int | `100` |  |
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
+| cronjob.enabled | bool | `true` |  |
+| cronjob.endpoints[0].endpoint | string | `"/api/clean"` |  |
+| cronjob.endpoints[0].schedule | string | `"*/30 * * * *"` |  |
+| cronjob.failedJobsHistoryLimit | int | `3` |  |
+| cronjob.image.pullPolicy | string | `"IfNotPresent"` |  |
+| cronjob.image.repository | string | `"alpine/curl"` |  |
+| cronjob.image.tag | string | `"8.8.0"` |  |
+| cronjob.resources | object | `{}` |  |
+| cronjob.successfulJobsHistoryLimit | int | `1` |  |
 | env[0].name | string | `"CLICKHOUSE_HOST"` |  |
 | env[0].value | string | `"http://localhost:8123"` |  |
 | env[1].name | string | `"CLICKHOUSE_USER"` |  |
@@ -32,7 +41,7 @@ A Helm chart for ClickHouse Monitoring (https://github.com/duyet/clickhouse-moni
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"Always"` |  |
 | image.repository | string | `"ghcr.io/duyet/clickhouse-monitoring"` |  |
-| image.tag | string | `"main"` |  |
+| image.tag | string | `"latest"` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.className | string | `""` |  |
@@ -46,10 +55,13 @@ A Helm chart for ClickHouse Monitoring (https://github.com/duyet/clickhouse-moni
 | podAnnotations | object | `{}` |  |
 | podLabels | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
+| port.containerPort | int | `3000` |  |
+| port.portName | string | `"http"` |  |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
 | securityContext | object | `{}` |  |
 | service.port | int | `3000` |  |
+| service.portName | string | `"http"` |  |
 | service.type | string | `"ClusterIP"` |  |
 | tolerations | list | `[]` |  |
 | volumeMounts | list | `[]` |  |

--- a/clickhouse-monitoring/README.md
+++ b/clickhouse-monitoring/README.md
@@ -21,15 +21,9 @@ A Helm chart for ClickHouse Monitoring (https://github.com/duyet/clickhouse-moni
 | autoscaling.maxReplicas | int | `100` |  |
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
-| cronjob.enabled | bool | `true` |  |
-| cronjob.endpoints[0].endpoint | string | `"/api/clean"` |  |
-| cronjob.endpoints[0].schedule | string | `"*/30 * * * *"` |  |
-| cronjob.failedJobsHistoryLimit | int | `3` |  |
-| cronjob.image.pullPolicy | string | `"IfNotPresent"` |  |
-| cronjob.image.repository | string | `"alpine/curl"` |  |
-| cronjob.image.tag | string | `"8.8.0"` |  |
-| cronjob.resources | object | `{}` |  |
-| cronjob.successfulJobsHistoryLimit | int | `1` |  |
+| cronjob | object | `{"enabled":true,"endpoints":[{"endpoint":"/api/clean","schedule":"*/30 * * * *"}],"failedJobsHistoryLimit":3,"image":{"pullPolicy":"IfNotPresent","repository":"alpine/curl","tag":"8.8.0"},"resources":{},"successfulJobsHistoryLimit":1}` | Enable cronjob for monitoring background tasks |
+| cronjob.endpoints[0].endpoint | string | `"/api/clean"` | Endpoint for the cron job to call, must be unique as using for generate cronjob name as well. |
+| cronjob.endpoints[0].schedule | string | `"*/30 * * * *"` | Cron schedule expression |
 | env[0].name | string | `"CLICKHOUSE_HOST"` |  |
 | env[0].value | string | `"http://localhost:8123"` |  |
 | env[1].name | string | `"CLICKHOUSE_USER"` |  |

--- a/clickhouse-monitoring/templates/_helpers.tpl
+++ b/clickhouse-monitoring/templates/_helpers.tpl
@@ -71,3 +71,14 @@ Usage:
 {{- define "clickhouse-monitoring.cronjobName" -}}
 {{- printf "%s-%s" (include "clickhouse-monitoring.fullname" .) .endpoint | replace "/" "-" | trunc 63 | trimSuffix "-" }}
 {{- end }}
+
+{{/*
+Cronjob API Version
+*/}}
+{{- define "clickhouse-monitoring.cronJobApiVersion" -}}
+{{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion -}}
+batch/v1
+{{- else -}}
+batch/v1beta1
+{{- end -}}
+{{- end -}}

--- a/clickhouse-monitoring/templates/_helpers.tpl
+++ b/clickhouse-monitoring/templates/_helpers.tpl
@@ -62,3 +62,12 @@ Usage:
         {{- tpl (.value | toYaml) .context }}
     {{- end }}
 {{- end -}}
+
+{{/*
+Cronjob name
+Usage:
+{{ include "clickhouse-monitoring.cronjobName" (merge $endpoint $) }}
+*/}}
+{{- define "clickhouse-monitoring.cronjobName" -}}
+{{- printf "%s-%s" (include "clickhouse-monitoring.fullname" .) .endpoint | replace "/" "-" | trunc 63 | trimSuffix "-" }}
+{{- end }}

--- a/clickhouse-monitoring/templates/cronjob.yaml
+++ b/clickhouse-monitoring/templates/cronjob.yaml
@@ -1,0 +1,89 @@
+{{- if $.Values.cronjob.enabled }}
+{{- range $endpoint := $.Values.cronjob.endpoints }}
+
+---
+apiVersion: batch/v1
+kind: Cronjob
+metadata:
+  name: {{ include "clickhouse-monitoring.cronjobName" (merge $endpoint $) }}
+  labels:
+    {{- include "clickhouse-monitoring.labels" $ | nindent 4 }}
+spec:
+  schedule: {{ $endpoint.schedule | quote }}
+  successfulJobsHistoryLimit: {{ $.Values.cronjob.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ $.Values.cronjob.failedJobsHistoryLimit }}
+  jobTemplate:
+    metadata:
+      {{- with $.Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "clickhouse-monitoring.labels" $ | nindent 8 }}
+        {{- with $.Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      template:
+        spec:
+          {{- with $.Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml $.Values.podSecurityContext | nindent 12 }}
+          containers:
+            - name: {{ $.Chart.Name }}
+              securityContext:
+                {{- toYaml $.Values.securityContext | nindent 16 }}
+              {{- with $.Values.cronjob.image }}
+              image: "{{ .repository }}:{{ .tag }}"
+              imagePullPolicy: {{ .pullPolicy | default $.Values.image.pullPolicy }}
+              {{- end }}
+              resources:
+                {{- toYaml $.Values.cronjob.resources | nindent 16 }}
+              env:
+                - name: ENDPOINT
+                  value: {{ include "clickhouse-monitoring.fullname" $ }}:{{ $.Values.service.port }}
+                {{- with $.Values.env }}
+                {{- toYaml . | nindent 16 }}
+                {{- end }}
+              {{- if or $.Values.extraEnvVarsCM $.Values.extraEnvVarsSecret }}
+              envFrom:
+                {{- if $.Values.extraEnvVarsCM }}
+                - configMapRef:
+                    name: {{ include "clickhouse-monitoring.tplValue" ( dict "value" $.Values.extraEnvVarsCM "context" $ ) }}
+                {{- end }}
+                {{- if $.Values.extraEnvVarsSecret }}
+                - secretRef:
+                    name: {{ include "clickhouse-monitoring.tplValue" ( dict "value" $.Values.extraEnvVarsSecret "context" $ ) }}
+                {{- end }}
+              {{- end }}
+              command:
+                - curl
+                - -H
+                - 'Content-type: application/json'
+                - $(ENDPOINT){{ $endpoint.endpoint }}
+
+              {{- with $.Values.volumeMounts }}
+              volumeMounts:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
+          {{- with $.Values.volumes }}
+          volumes:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $.Values.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $.Values.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $.Values.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}
+{{- end }}

--- a/clickhouse-monitoring/templates/cronjob.yaml
+++ b/clickhouse-monitoring/templates/cronjob.yaml
@@ -3,7 +3,7 @@
 
 ---
 apiVersion: batch/v1
-kind: Cronjob
+kind: CronJob
 metadata:
   name: {{ include "clickhouse-monitoring.cronjobName" (merge $endpoint $) }}
   labels:

--- a/clickhouse-monitoring/templates/cronjob.yaml
+++ b/clickhouse-monitoring/templates/cronjob.yaml
@@ -2,7 +2,7 @@
 {{- range $endpoint := $.Values.cronjob.endpoints }}
 
 ---
-apiVersion: batch/v1
+apiVersion: {{ include "clickhouse-monitoring.cronJobApiVersion" $ }}
 kind: CronJob
 metadata:
   name: {{ include "clickhouse-monitoring.cronjobName" (merge $endpoint $) }}

--- a/clickhouse-monitoring/values.yaml
+++ b/clickhouse-monitoring/values.yaml
@@ -22,6 +22,34 @@ env:
   - name: CLICKHOUSE_PASSWORD
     value: ''
 
+cronjob:
+  enabled: true
+
+  endpoints:
+    - schedule: "*/30 * * * *"
+      endpoint: /api/clean
+
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+
+  image:
+    repository: alpine/curl
+    tag: 8.8.0
+    pullPolicy: IfNotPresent
+
+  resources:
+    {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
 # Name of a ConfigMap containing extra env vars
 extraEnvVarsCM:
 # Name of a Secret containing extra env vars

--- a/clickhouse-monitoring/values.yaml
+++ b/clickhouse-monitoring/values.yaml
@@ -22,11 +22,14 @@ env:
   - name: CLICKHOUSE_PASSWORD
     value: ''
 
+# -- Enable cronjob for monitoring background tasks
 cronjob:
   enabled: true
 
   endpoints:
-    - schedule: "*/30 * * * *"
+    - # -- Cron schedule expression
+      schedule: "*/30 * * * *"
+      # -- Endpoint for the cron job to call, must be unique as using for generate cronjob name as well.
       endpoint: /api/clean
 
   successfulJobsHistoryLimit: 1


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request adds a new cronjob feature to the ClickHouse monitoring Helm chart, enabling scheduled tasks. The Helm chart version is updated to 0.1.2, and the README.md is updated to include documentation for the new cronjob configuration options.

- **New Features**:
    - Introduced a cronjob feature in the ClickHouse monitoring Helm chart, allowing scheduled tasks to be configured and executed.
- **Enhancements**:
    - Updated the Helm chart version to 0.1.2 to reflect the new changes.
- **Documentation**:
    - Updated README.md to document the new cronjob configuration options.

<!-- Generated by sourcery-ai[bot]: end summary -->