### PR TITLE
fix(ci): set chart-testing target-branch to master (unblock lint queue)

### DIFF
--- a/.github/ct-install.yaml
+++ b/.github/ct-install.yaml
@@ -2,6 +2,7 @@ chart-dirs:
   - .
 debug: true
 remote: origin
+target-branch: master
 chart-repos:
   - bitnami=https://charts.bitnami.com/bitnami
   - stable=https://charts.helm.sh/stable

--- a/.github/ct-lint.yaml
+++ b/.github/ct-lint.yaml
@@ -3,6 +3,7 @@ chart-dirs:
 check-version-increment: false
 debug: true
 remote: origin
+target-branch: master
 validate-chart-schema: true
 validate-maintainers: true
 validate-yaml: true

--- a/.github/workflows/chart-lint.yml
+++ b/.github/workflows/chart-lint.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed | tr '\n' ' ')
+          changed=$(ct list-changed --config .github/ct-lint.yaml | tr '\n' ' ')
           echo "list_changed=$changed" >> $GITHUB_ENV
           if [[ -n "$changed" ]]; then
             echo "changed=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Every chart-lint/install run fails with `targetBranch 'origin/main' does not exist` — chart-testing defaults to `main` but this repo's default branch is `master`.

Changes:
- `.github/ct-lint.yaml` + `.github/ct-install.yaml`: add `target-branch: master`
- `.github/workflows/chart-lint.yml`: pass `--config .github/ct-lint.yaml` to `ct list-changed` (it ran without config, ignoring the setting)

Once green this unblocks the dep-bump queue (#197 curl, #198 chart-testing-action; and lets #215/#200 elasticsearch be triaged on real chart merits).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD configuration to specify target branch (`master`) for chart testing and validation processes.
  * Modified workflow to use explicit configuration files for chart testing instead of default settings, improving consistency in how changed charts are identified and processed in the pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->