### PR TITLE
fix(ci): yamllint comment spacing in clickhouse-monitoring values.yaml

### DIFF
--- a/clickhouse-monitoring/values.yaml
+++ b/clickhouse-monitoring/values.yaml
@@ -27,7 +27,7 @@ cronjob:
   enabled: true
 
   endpoints:
-    - # -- Cron schedule expression
+    -  # -- Cron schedule expression
       schedule: "*/30 * * * *"
       # -- Endpoint for the cron job to call, must be unique as using for generate cronjob name as well.
       endpoint: /api/clean


### PR DESCRIPTION
Fixes yamllint 'too few spaces before comment' violations in clickhouse-monitoring/values.yaml. This unblocks chart-lint CI on PRs #197 and #198.